### PR TITLE
Fix error caused by missing "locale" HTTP-header

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.formula1" name="Formula 1" version="2.0.4" provider-name="jaylinski">
+<addon id="plugin.video.formula1" name="Formula 1" version="2.0.5" provider-name="jaylinski">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.29.0"/>
@@ -16,7 +16,10 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=352138</forum>
         <website>https://www.formula1.com</website>
         <source>https://github.com/jaylinski/kodi-addon-formula1</source>
-        <news>2.0.4 (2025-04-05)
+        <news>2.0.5 (2025-06-17)
+Fixed error when selecting the "Videos" folder
+
+2.0.4 (2025-04-05)
 Fixed error when selecting the "Race results"-item in the "Standings"-section
 
 2.0.3 (2024-12-22)

--- a/resources/lib/f1/api.py
+++ b/resources/lib/f1/api.py
@@ -21,6 +21,7 @@ class Api:
     api_key = "RNoNDmjJGUFSu1Re9GfMVzJfDClaUV47"  # Extracted from public Formula 1 Android App
     api_limit = 10
     api_date_format = "%Y-%m-%dT%H:%M:%S"
+    api_locale = "en"
 
     # API endpoints
     api_path_editorial = "/v1/editorial-assemblies/videos/2BiKQUC040cmuysoQsgwcK"
@@ -89,6 +90,7 @@ class Api:
         headers = {
             "Accept-Encoding": "gzip",
             "apikey": self.api_key,
+            "locale": self.api_locale,
         }
         path = self.api_base_url + path
 


### PR DESCRIPTION
The "videos"-endpoint no requires a "locale" HTTP header to be set.
Right now we just use "en", but we could make this configurable in the future.